### PR TITLE
Bugfix: Stopped adding machine back into db after deleting

### DIFF
--- a/src/main/java/org/icatproject/topcatdaaasplugin/LastActivity.java
+++ b/src/main/java/org/icatproject/topcatdaaasplugin/LastActivity.java
@@ -70,7 +70,6 @@ public class LastActivity {
                         Map<String, Object> params = new HashMap<>();
                         params.put("id", machine.getId());
                         database.remove(machine);
-                        database.persist(machine);
                     }
                 } catch (Exception e) {
                     logger.error("Something went wrong checking last activity: {}", e.getMessage());


### PR DESCRIPTION
### Description of work
Fixed bug where a machine was being added back into the machine table after it had been deleted.

### Ticket
#19

### Documentation
N/A

---

### Code Review
- [ ] [Is the code of an acceptable quality?]
- [ ] [Unit tests added]
- [ ] [System tests added]
- [ ] [Has the documentation been updated satisfactorily]
