### PR TITLE
copy paste Firefox on mac fix

### DIFF
--- a/src/main/webapp/scripts/custom.js
+++ b/src/main/webapp/scripts/custom.js
@@ -82,7 +82,9 @@ $(document).ready(function(){
         ctrlKey = 17,
         shiftKey = 16,
         insertKey = 45,
-        cmdKey = 91,
+        lcmdKey = 91,
+        rcmdKey = 93,
+        firefoxcmdkey = 224,
         vKey = 86,
         xKey = 88,
         cKey = 67;
@@ -93,11 +95,11 @@ $(document).ready(function(){
         // add eventlisteners to detect when ctrl/cmd are held down
         $("canvas").keydown(function(e) {
             if (e.keyCode == ctrlKey) ctrlDown = true;
-            if (e.keyCode == cmdKey) cmdDown = true;
+            if (e.keyCode == lcmdKey || e.keyCode == rcmdKey || e.keyCode == firefoxcmdkey) cmdDown = true;
             if (e.keyCode == shiftKey) shiftDown = true;
         }).keyup(function(e) {
             if (e.keyCode == ctrlKey) ctrlDown = false;
-            if (e.keyCode == cmdKey) cmdDown = false;
+            if (e.keyCode == lcmdKey || e.keyCode == rcmdKey || e.keyCode == firefoxcmdkey) cmdDown = false;
             if (e.keyCode == shiftKey) shiftDown = false;
         });
         


### PR DESCRIPTION
Firefox uses a different key code 224 for both cmd keys,
added additional listeners for them

### Description of work
Fixed copy-paste on firefox on mac by adding key listeners for additional types of CMD presses

### Ticket
[Link to the ticket and/or issue this resolves, if applicable (can be written as simply #123)]

### Documentation
[Have you updated the documentation, where?]

---

### Code Review
- [ ] [Is the code of an acceptable quality?]
- [ ] [Unit tests added]
- [ ] [System tests added]
- [ ] [Has the documentation been updated satisfactorily]
