### PR TITLE
Bugfix lastactivity delete

### DIFF
--- a/src/main/java/org/icatproject/topcatdaaasplugin/LastActivity.java
+++ b/src/main/java/org/icatproject/topcatdaaasplugin/LastActivity.java
@@ -60,6 +60,7 @@ public class LastActivity {
 
                     if (difference > deleteTime) {
                         logger.info("Inactivity on machine {} is greater than deleteTime. Deleting", machine.getId());
+                        database.remove(machine);
                         try {
                             vmmClient.delete_machine(machine.getId());
                         } catch (UnexpectedException e) {
@@ -69,7 +70,6 @@ public class LastActivity {
                         }
                         Map<String, Object> params = new HashMap<>();
                         params.put("id", machine.getId());
-                        database.remove(machine);
                     }
                 } catch (Exception e) {
                     logger.error("Something went wrong checking last activity: {}", e.getMessage());

--- a/src/main/java/org/icatproject/topcatdaaasplugin/LastActivity.java
+++ b/src/main/java/org/icatproject/topcatdaaasplugin/LastActivity.java
@@ -68,8 +68,6 @@ public class LastActivity {
                         } catch (Exception e) {
                             throw new UnexpectedException(e.getMessage());
                         }
-                        Map<String, Object> params = new HashMap<>();
-                        params.put("id", machine.getId());
                     }
                 } catch (Exception e) {
                     logger.error("Something went wrong checking last activity: {}", e.getMessage());


### PR DESCRIPTION
### Description of work
Last Activity will now delete from Topcat DB before VMM DB, so the users won't be able to see dead VM links if something goes wrong with the deletion.

Removed a couple of other lines which are no longer used.

### Ticket
https://jira.atlassiansw.scd.rl.ac.uk/browse/IDAAAS-179

### Documentation
N/A

---

### Code Review
- [ ] [Is the code of an acceptable quality?]
- [ ] [Unit tests added]
- [ ] [System tests added]
- [ ] [Has the documentation been updated satisfactorily]
