### PR TITLE
Use interactive terminal for ssh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.icatproject</groupId>
 	<artifactId>topcat_daaas_plugin</artifactId>
 	<packaging>war</packaging>
-  <version>1.6</version>
+  <version>1.7</version>
 	<name>TopCAT DAaaS Plugin</name>
 	<description>Web frontend for multiple ICATs</description>
 

--- a/src/main/java/org/icatproject/topcatdaaasplugin/SshClient.java
+++ b/src/main/java/org/icatproject/topcatdaaasplugin/SshClient.java
@@ -28,7 +28,7 @@ public class SshClient {
         String sshUsername = properties.getProperty("sshUsername");
 
         String[] command = new String[]{
-                "/usr/bin/ssh", sshUsername + "@" + host,
+                "/usr/bin/ssh", "-t", sshUsername + "@" + host,
                 "-i", sshPrivateKeyFile,
                 "-o", "StrictHostKeyChecking no",
                 "-o", "UserKnownHostsFile /dev/null",

--- a/src/main/java/org/icatproject/topcatdaaasplugin/rest/UserResource.java
+++ b/src/main/java/org/icatproject/topcatdaaasplugin/rest/UserResource.java
@@ -158,15 +158,6 @@ public class UserResource {
             logger.debug("createMachine: add_websockify_token " + machineUser.getWebsockifyToken());
             sshClient.exec("add_websockify_token " + machineUser.getWebsockifyToken());
 
-            String group = vmmClient.get_machine_type(machineTypeId).get_group();
-            /*
-                This really needs to be abstracted out into a config file.
-            */
-            if ("excitations".equals(group) || "wish".equals(group)) {
-                logger.debug("createMachine: custom excitations " + machineUser.getWebsockifyToken());
-                sshClient.exec("custom excitations " + fedId + " " + userName.replace("uows/", ""));
-            }
-
             machine.setScreenshot(Base64.getMimeDecoder().decode(sshClient.exec("get_screenshot")));
             machine.setCreatedAt(new Date());
             database.persist(machine);


### PR DESCRIPTION
### Description of work
Adds the `-t` flag to ssh command, making it an interactive session, which allows the connection to disconnect when the original process finishes, rather than waiting for all its child processes to complete.

So we can start commands off inside the script with `nohup COMMAND &` and they will run in the background without holding up the code in the front end.
